### PR TITLE
Fix reporting wrong PD.ID in PD LLD

### DIFF
--- a/adaptec-raid.sh
+++ b/adaptec-raid.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #    .VERSION
-#    0.3
+#    0.4
 #
 #    .DESCRIPTION
 #    Author: Nikitin Maksim
@@ -10,7 +10,7 @@
 #
 #    .TESTING
 #    OS: CentOS 7 x64
-#    Controller RAID: ASR8405, ASR-8405E, Adaptec 6805, Adaptec 6405E
+#    Controller RAID: ASR8405, ASR-8405E, Adaptec 6805, Adaptec 6405E, ASR8805
 #
 
 CLI='/opt/StorMan/arcconf'
@@ -81,18 +81,18 @@ LLDPhysicalDrives() {
     
     for ctrl_id in $(seq 1 ${ctrl_count}); do
         IFS=$'\n'
-        response=($($CLI GETCONFIG ${ctrl_id} PD | grep -e "Device #" -e "Device is" -e "Serial number"))
+        response=($($CLI GETCONFIG ${ctrl_id} PD | grep -e "Device #" -e "Device is" -e "Reported Channel,Device(T:L)" -e "Serial number"))
         i=0
         while [ $i -lt ${#response[@]} ]; do
-            pd_id=$(echo ${response[${i}]} | cut -f2 -d"#")
+            pd_id=$(echo ${response[$((${i}+2))]} | awk '{print $4}' | sed -e 's/.*,\(.*\)(.*/\1/')
             pd_type=$(echo ${response[$((${i}+1))]} | cut -f2 -d":" | sed -e 's/^\s*//' -e 's/ /_/g')
             if [[ ! ${pd_type} =~ "Enclosure_Services_Device" ]]; then
-                pd_sn=$(echo ${response[$((${i}+2))]} | cut -f2 -d":" | sed -e 's/^\s*//')
+                pd_sn=$(echo ${response[$((${i}+3))]} | cut -f2 -d":" | sed -e 's/^\s*//')
                 if [ ${#pd_sn} -gt 0 ]; then
                     pd_json=${pd_json}"{\"{#CTRL.ID}\":\"${ctrl_id}\",\"{#PD.ID}\":\"${pd_id}\",\"{#PD.SN}\":\"${pd_sn}\"},"
                 fi
             fi
-            i=$(($i+3))
+            i=$(($i+4))
         done
     done
 


### PR DESCRIPTION
Zabbix had problems reading the physical drive (PD) health status. I found out the problem is, that the PD LLD (`adaptec-raid.sh lld pd`) reports the PD.IDs always from 0 on ascending.

In our case the IDs start at 8, therefore `adaptec-raid.sh health pd 1 0` fails. Correct would be `adaptec-raid.sh health pd 1 8`.

I changed the PD LLD method to return the correct PD.IDs reported by the CLI.

Unfortunately I am not very proficient with PowerShell and don't have a Windows machine with a RAID controller to test some hacked-together code, so I cannot provide the fix for `adaptec-raid.ps1`.